### PR TITLE
Support dynamics w/ heteroscedastic noise

### DIFF
--- a/diffbayes/base/_dynamics_model.py
+++ b/diffbayes/base/_dynamics_model.py
@@ -29,10 +29,10 @@ class DynamicsModel(nn.Module, abc.ABC):
         """Dynamics model forward pass, single timestep.
 
         Computes both predicted states and uncertainties. Note that uncertainties
-        correspond to the "Q" matrix in a standard linear dynamical system w/ additive
-        white Gaussian noise and should not accumulate. In other words, the covariance
-        at time `t` should be computed as if the estimate at time `t - 1` is a
-        ground-truth input.
+        correspond to the (Cholesky decompositions of the) "Q" matrices in a standard
+        linear dynamical system w/ additive white Gaussian noise. In other words, they
+        should be lower triangular and not accumulate -- the uncertainty at at time `t`
+        should be computed as if the estimate at time `t - 1` is a ground-truth input.
 
         By default, this is implemented by bootstrapping the `forward_loop()`
         method.
@@ -43,9 +43,10 @@ class DynamicsModel(nn.Module, abc.ABC):
                 dict of tensors or tensor of size `(N, ...)`.
 
         Returns:
-            Tuple[torch.Tensor, torch.Tensor]: Predicted states & covariances.
+            Tuple[torch.Tensor, torch.Tensor]: Predicted states & uncertainties.
                 - States should have shape `(N, state_dim).`
-                - Covariances should have shape `(N, state_dim, state_dim).`
+                - Uncertainties should be lower triangular, and should have shape
+                `(N, state_dim, state_dim).`
         """
 
         # Wrap our control inputs
@@ -55,12 +56,12 @@ class DynamicsModel(nn.Module, abc.ABC):
         controls = fannypack.utils.SliceWrapper(controls)
 
         # Call `forward_loop()` with a single timestep
-        predictions, covariances = self.forward_loop(
+        predictions, scale_trils = self.forward_loop(
             initial_states=initial_states, controls=controls[None, ...]
         )
         assert predictions.shape[0] == 1
-        assert covariances.shape[0] == 1
-        return predictions[0], covariances[0]
+        assert scale_trils.shape[0] == 1
+        return predictions[0], scale_trils[0]
 
     def forward_loop(
         self, *, initial_states: types.StatesTorch, controls: types.ControlsTorch,
@@ -70,10 +71,10 @@ class DynamicsModel(nn.Module, abc.ABC):
         `forward()`.
 
         Computes both predicted states and uncertainties. Note that uncertainties
-        correspond to the "Q" matrix in a standard linear dynamical system w/ additive
-        white Gaussian noise and should not accumulate. In other words, the covariance
-        at time `t` should be computed as if the estimate at time `t - 1` is a
-        ground-truth input.
+        correspond to the (Cholesky decompositions of the) "Q" matrices in a standard
+        linear dynamical system w/ additive white Gaussian noise. In other words, they
+        should be lower triangular and not accumulate -- the uncertainty at at time `t`
+        should be computed as if the estimate at time `t - 1` is a ground-truth input.
 
         To inject code between timesteps (for example, to inspect hidden state),
         use `register_forward_hook()`.
@@ -84,9 +85,10 @@ class DynamicsModel(nn.Module, abc.ABC):
             controls (dict or torch.Tensor): Control inputs. Should be either a
                 dict of tensors or tensor of size `(T, N, ...)`.
         Returns:
-            Tuple[torch.Tensor, torch.Tensor]: Predicted states & covariances.
+            Tuple[torch.Tensor, torch.Tensor]: Predicted states & uncertainties.
                 - States should have shape `(T, N, state_dim).`
-                - Covariances should have shape `(T, N, state_dim, state_dim).`
+                - Uncertainties should be lower triangular, and should have shape
+                `(T, N, state_dim, state_dim).`
         """
 
         # Wrap our control inputs
@@ -102,8 +104,8 @@ class DynamicsModel(nn.Module, abc.ABC):
         assert T > 0
 
         # Dynamics forward pass
-        pred_list: List[types.StatesTorch] = []
-        cov_list: List[torch.Tensor] = []
+        predictions_list: List[types.StatesTorch] = []
+        scale_trils_list: List[torch.Tensor] = []
 
         constant_noise = True
         prediction = initial_states
@@ -111,39 +113,39 @@ class DynamicsModel(nn.Module, abc.ABC):
         for t in range(T):
             # Compute state estimate for a single timestep
             # We use __call__ to make sure hooks are dispatched correctly
-            prediction, covariance = self(
+            prediction, scale_tril = self(
                 initial_states=prediction, controls=controls[t]
             )
 
             # Check if noise is time-varying
             if t >= 1 and (
-                covariance.data_ptr() != cov_list[-1].data_ptr() # type: ignore
-                or covariance.stride() != cov_list[-1].stride()
+                scale_tril.data_ptr() != scale_trils_list[-1].data_ptr()  # type: ignore
+                or scale_tril.stride() != scale_trils_list[-1].stride()
             ):
                 constant_noise = False
 
             # Validate & add to output
             assert prediction.shape == (N, self.state_dim)
-            assert covariance.shape == (N, self.state_dim, self.state_dim)
-            pred_list.append(prediction)
-            cov_list.append(covariance)
+            assert scale_tril.shape == (N, self.state_dim, self.state_dim)
+            predictions_list.append(prediction)
+            scale_trils_list.append(scale_tril)
 
         # Stack predictions
-        predictions = torch.stack(pred_list, dim=0)
+        predictions = torch.stack(predictions_list, dim=0)
 
-        # Stack covariances
+        # Stack uncertainties
         if constant_noise:
             # If our noise is constant, we save memory by returning a strided view of
             # the first tensor in the list
-            covariances = cov_list[0][None, :, :, :].expand(
+            scale_trils = scale_trils_list[0][None, :, :, :].expand(
                 T, N, self.state_dim, self.state_dim
             )
         else:
             # If our noise is time-varying, stack normally
-            covariances = torch.stack(cov_list, dim=0)
+            scale_trils = torch.stack(scale_trils_list, dim=0)
             assert False
 
         # Validate & return state estimates
         assert predictions.shape == (T, N, self.state_dim)
-        assert covariances.shape == (T, N, self.state_dim, self.state_dim)
-        return predictions, covariances
+        assert scale_trils.shape == (T, N, self.state_dim, self.state_dim)
+        return predictions, scale_trils

--- a/diffbayes/base/_dynamics_model.py
+++ b/diffbayes/base/_dynamics_model.py
@@ -1,4 +1,5 @@
 import abc
+from typing import List, Tuple
 
 import torch
 import torch.nn as nn
@@ -9,29 +10,29 @@ from .. import types
 
 
 class DynamicsModel(nn.Module, abc.ABC):
-    """Base class for a generic differentiable dynamics model.
+    """Base class for a generic differentiable dynamics model, with additive white
+    Gaussian noise.
 
-    As a minimum, subclasses should override either `forward` or `forward_loop`
-    for computing dynamics estimates.
+    Subclasses should override either `forward` or `forward_loop` for computing dynamics
+    estimates.
     """
 
-    def __init__(self, *, state_dim: int, Q: torch.Tensor) -> None:
+    def __init__(self, *, state_dim: int) -> None:
         super().__init__()
 
         self.state_dim = state_dim
         """int: Dimensionality of our state."""
 
-        self.Q = torch.nn.Parameter(Q, requires_grad=False)
-        """torch.Tensor: Output covariance."""
-
     def forward(
-        self,
-        *,
-        initial_states: types.StatesTorch,
-        controls: types.ControlsTorch,
-        noisy: bool,
-    ) -> types.StatesTorch:
+        self, *, initial_states: types.StatesTorch, controls: types.ControlsTorch,
+    ) -> Tuple[types.StatesTorch, torch.Tensor]:
         """Dynamics model forward pass, single timestep.
+
+        Computes both predicted states and uncertainties. Note that uncertainties
+        correspond to the "Q" matrix in a standard linear dynamical system w/ additive
+        white Gaussian noise and should not accumulate. In other words, the covariance
+        at time `t` should be computed as if the estimate at time `t - 1` is a
+        ground-truth input.
 
         By default, this is implemented by bootstrapping the `forward_loop()`
         method.
@@ -40,11 +41,11 @@ class DynamicsModel(nn.Module, abc.ABC):
             initial_states (torch.Tensor): Initial states of our system.
             controls (dict or torch.Tensor): Control inputs. Should be either a
                 dict of tensors or tensor of size `(N, ...)`.
-            noisy (bool): Set to True to add noise to output.
 
         Returns:
-            torch.Tensor: Predicted state for each batch element. Shape should
-            be `(N, state_dim).`
+            Tuple[torch.Tensor, torch.Tensor]: Predicted states & covariances.
+                - States should have shape `(N, state_dim).`
+                - Covariances should have shape `(N, state_dim, state_dim).`
         """
 
         # Wrap our control inputs
@@ -54,22 +55,26 @@ class DynamicsModel(nn.Module, abc.ABC):
         controls = fannypack.utils.SliceWrapper(controls)
 
         # Call `forward_loop()` with a single timestep
-        output = self.forward_loop(
-            initial_states=initial_states, controls=controls[None, ...], noisy=noisy
+        predictions, covariances = self.forward_loop(
+            initial_states=initial_states, controls=controls[None, ...]
         )
-        assert output.shape[0] == 1
-        return output[0]
+        assert predictions.shape[0] == 1
+        assert covariances.shape[0] == 1
+        return predictions[0], covariances[0]
 
     def forward_loop(
-        self,
-        *,
-        initial_states: types.StatesTorch,
-        controls: types.ControlsTorch,
-        noisy: bool,
-    ) -> types.StatesTorch:
+        self, *, initial_states: types.StatesTorch, controls: types.ControlsTorch,
+    ) -> Tuple[types.StatesTorch, torch.Tensor]:
         """Dynamics model forward pass, over sequence length `T` and batch size
         `N`.  By default, this is implemented by iteratively calling
         `forward()`.
+
+        Computes both predicted states and uncertainties. Note that uncertainties
+        correspond to the "Q" matrix in a standard linear dynamical system w/ additive
+        white Gaussian noise and should not accumulate. In other words, the covariance
+        at time `t` should be computed as if the estimate at time `t - 1` is a
+        ground-truth input.
+
         To inject code between timesteps (for example, to inspect hidden state),
         use `register_forward_hook()`.
 
@@ -78,10 +83,10 @@ class DynamicsModel(nn.Module, abc.ABC):
                 dynamics model. Shape should be `(N, state_dim)`.
             controls (dict or torch.Tensor): Control inputs. Should be either a
                 dict of tensors or tensor of size `(T, N, ...)`.
-            noisy (bool): Set to True to add noise to output.
         Returns:
-            torch.Tensor: Predicted states at each timestep. Shape should be
-            `(T, N, state_dim).`
+            Tuple[torch.Tensor, torch.Tensor]: Predicted states & covariances.
+                - States should have shape `(T, N, state_dim).`
+                - Covariances should have shape `(T, N, state_dim, state_dim).`
         """
 
         # Wrap our control inputs
@@ -94,30 +99,51 @@ class DynamicsModel(nn.Module, abc.ABC):
         T = controls.shape[0]
         N = controls.shape[1]
         assert initial_states.shape == (N, self.state_dim)
+        assert T > 0
 
         # Dynamics forward pass
-        state_predictions = initial_states.new_zeros((T, N, self.state_dim))
-        current_estimate = initial_states
+        pred_list: List[types.StatesTorch] = []
+        cov_list: List[torch.Tensor] = []
+
+        constant_noise = True
+        current_prediction = initial_states
+
         for t in range(T):
             # Compute state estimate for a single timestep
             # We use __call__ to make sure hooks are dispatched correctly
-            current_estimate = self(
-                initial_states=current_estimate, controls=controls[t], noisy=noisy
+            current_prediction, current_covariance = self(
+                initial_states=current_prediction, controls=controls[t]
             )
 
+            # Check if noise is time-varying
+            if t >= 1 and (
+                current_covariance.data_ptr() != cov_list[-1].data_ptr()
+                or current_covariance.stride() != cov_list[-1].stride()
+            ):
+                constant_noise = False
+
             # Validate & add to output
-            assert current_estimate.shape == (N, self.state_dim)
-            state_predictions[t] = current_estimate
+            assert current_prediction.shape == (N, self.state_dim)
+            assert current_covariance.shape == (N, self.state_dim, self.state_dim)
+            pred_list.append(current_prediction)
+            cov_list.append(current_covariance)
 
-        # Return state estimates
-        return state_predictions
+        # Stack predictions
+        predictions = torch.stack(pred_list, dim=0)
 
-    def add_noise(self, *, states: torch.Tensor, enabled: bool):
-        """Protected helper for adding Gaussian noise to a set of states.
-        """
-        if not enabled:
-            return
-        N, state_dim = states.shape
-        output = torch.distributions.MultivariateNormal(states, self.Q).sample()
-        assert output.shape == (N, state_dim)
-        return output
+        # Stack covariances
+        if constant_noise:
+            # If our noise is constant, we save memory by returning a strided view of
+            # the first tensor in the list
+            covariances = cov_list[0][None, :, :, :].expand(
+                T, N, self.state_dim, self.state_dim
+            )
+        else:
+            # If our noise is time-varying, stack normally
+            covariances = torch.stack(cov_list, dim=0)
+            assert False
+
+        # Validate & return state estimates
+        assert predictions.shape == (T, N, self.state_dim)
+        assert covariances.shape == (T, N, self.state_dim, self.state_dim)
+        return predictions, covariances

--- a/diffbayes/base/_measurement_models.py
+++ b/diffbayes/base/_measurement_models.py
@@ -24,7 +24,7 @@ class ParticleFilterMeasurementModel(abc.ABC, nn.Module):
     ) -> types.StatesTorch:
         """Observation model forward pass, over batch size `N`.
         For each member of a batch, we expect `M` separate states (particles)
-        and just one unique observation.
+        and one unique observation.
 
         Args:
             states (torch.Tensor): States to pass to our observation model.

--- a/diffbayes/base/_particle_filter.py
+++ b/diffbayes/base/_particle_filter.py
@@ -189,11 +189,13 @@ class ParticleFilter(Filter, abc.ABC):
         reshaped_controls = fannypack.utils.SliceWrapper(controls).map(
             lambda tensor: torch.repeat_interleave(tensor, repeats=M, dim=0)
         )
-        predicted_states, covariances = self.dynamics_model(
+        predicted_states, scale_trils = self.dynamics_model(
             initial_states=reshaped_states, controls=reshaped_controls
         )
         self.particle_states = (
-            torch.distributions.MultivariateNormal(predicted_states, covariances)
+            torch.distributions.MultivariateNormal(
+                loc=predicted_states, scale_tril=scale_trils
+            )
             .sample()
             .view(N, M, self.state_dim)
         )

--- a/diffbayes/data/_single_step_dataset.py
+++ b/diffbayes/data/_single_step_dataset.py
@@ -21,7 +21,14 @@ class SingleStepDataset(Dataset):
     def __init__(self, trajectories: List[types.TrajectoryTupleNumpy]):
         # Split trajectory into samples:
         #   (initial_state, next_state, observation, control)
-        self.samples = []
+        self.samples: List[
+            Tuple[
+                types.StatesNumpy,
+                types.StatesNumpy,
+                types.ObservationsNumpy,
+                types.ControlsNumpy,
+            ]
+        ] = []
 
         for trajectory in trajectories:
             states, observations, controls = trajectory

--- a/diffbayes/train/_train_dynamics.py
+++ b/diffbayes/train/_train_dynamics.py
@@ -21,7 +21,7 @@ def train_dynamics_single_step(
     dynamics_model: diffbayes.base.DynamicsModel,
     dataloader: DataLoader,
     *,
-    loss_function: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] = F.mse_loss,
+    loss_function: str = "nll",
     log_interval: int = 10,
 ) -> None:
     """Optimizes a dynamics model's single-step prediction accuracy.
@@ -32,12 +32,13 @@ def train_dynamics_single_step(
         dataloader (DataLoader): Loader for a SingleStepDataset.
 
     Keyword Args:
-        loss_function (callable, optional): Loss function, from `torch.nn.functional`.
-            Defaults to MSE.
+        loss_function (str, optional): Either "nll" for negative log-likelihood or "mse"
+            for mean-squared error. Defaults to "nll".
         log_interval (int, optional): Minibatches between each Tensorboard log.
     """
-    # Dataloader should load a SingleStepDataset
+    # Input validation
     assert isinstance(dataloader.dataset, diffbayes.data.SingleStepDataset)
+    assert loss_function in ("nll", "mse")
     assert dynamics_model.training, "Model needs to be set to train mode"
 
     # Track mean epoch loss
@@ -58,23 +59,40 @@ def train_dynamics_single_step(
             assert fannypack.utils.SliceWrapper(controls).shape[:1] == (N,)
 
             # Single-step prediction
-            state_predictions = dynamics_model(
-                initial_states=initial_states, controls=controls, noisy=False
+            predictions, covariances = dynamics_model(
+                initial_states=initial_states, controls=controls
             )
-            assert state_predictions.shape == (N, state_dim)
+            assert predictions.shape == (N, state_dim)
+
+            # Check if we want to log
+            log_flag = batch_idx % log_interval == 0
 
             # Minimize loss
-            loss = loss_function(state_predictions, next_states)
-            buddy.minimize(loss, optimizer_name="train_dynamics_single_step")
-            epoch_loss += fannypack.utils.to_numpy(loss)
+            losses = {}
+            if log_flag or loss_function == "mse":
+                losses["mse"] = F.mse_loss(predictions, next_states)
+            if log_flag or loss_function == "nll":
+                log_likelihoods = torch.distributions.MultivariateNormal(
+                    predictions, covariances
+                ).log_prob(next_states)
+                assert log_likelihoods.shape == (N,)
+                losses["nll"] = -torch.sum(log_likelihoods)
+
+            buddy.minimize(
+                losses[loss_function], optimizer_name="train_dynamics_single_step"
+            )
+            epoch_loss += fannypack.utils.to_numpy(losses[loss_function])
 
             # Logging
-            if batch_idx % log_interval == 0:
-                buddy.log("loss", loss)
+            if log_flag:
+                buddy.log("MSE loss", losses["mse"])
+                buddy.log("NLL loss", losses["nll"])
 
     # Print average training loss
     epoch_loss /= len(dataloader)
-    print("(train_dynamics_single_step) Epoch training loss: ", epoch_loss)
+    print(
+        f"(train_dynamics_single_step) Epoch training loss ({loss_function}): {epoch_loss}"
+    )
 
 
 def train_dynamics_recurrent(
@@ -82,7 +100,7 @@ def train_dynamics_recurrent(
     dynamics_model: diffbayes.base.DynamicsModel,
     dataloader: DataLoader,
     *,
-    loss_function: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] = F.mse_loss,
+    loss_function: str = "nll",
     log_interval: int = 10,
 ) -> None:
     """Trains a dynamics model via backpropagation through time.
@@ -93,12 +111,14 @@ def train_dynamics_recurrent(
         dataloader (DataLoader): Loader for a SubsequenceDataset.
 
     Keyword Args:
-        loss_function (callable, optional): Loss function, from `torch.nn.functional`.
-            Defaults to MSE.
+        loss_function (str, optional): Either "nll" for negative log-likelihood or "mse"
+            for mean-squared error. Defaults to "nll".
         log_interval (int, optional): Minibatches between each Tensorboard log.
     """
-    # Dataloader should load a SubsequenceDataset
+    # Input validation
     assert isinstance(dataloader.dataset, diffbayes.data.SubsequenceDataset)
+    assert loss_function in ("nll", "mse")
+    assert dynamics_model.training, "Model needs to be set to train mode"
 
     # Track mean epoch loss
     epoch_loss = 0.0
@@ -128,20 +148,37 @@ def train_dynamics_recurrent(
 
             # Forward pass from the first state
             initial_states = true_states[0]
-            state_predictions = dynamics_model.forward_loop(
-                initial_states=initial_states, controls=controls[1:], noisy=False
+            predictions, covariances = dynamics_model.forward_loop(
+                initial_states=initial_states, controls=controls[1:]
             )
-            assert state_predictions.shape == (T - 1, N, state_dim)
+            assert predictions.shape == (T - 1, N, state_dim)
+
+            # Check if we want to log
+            log_flag = batch_idx % log_interval == 0
 
             # Minimize loss
-            loss = loss_function(state_predictions, true_states[1:])
-            buddy.minimize(loss, optimizer_name="train_dynamics_recurrent")
-            epoch_loss += fannypack.utils.to_numpy(loss)
+            losses = {}
+            if log_flag or loss_function == "mse":
+                losses["mse"] = F.mse_loss(predictions, true_states[1:])
+            if log_flag or loss_function == "nll":
+                log_likelihoods = torch.distributions.MultivariateNormal(
+                    predictions, covariances
+                ).log_prob(true_states[1:])
+                assert log_likelihoods.shape == (T - 1, N)
+                losses["nll"] = -torch.sum(log_likelihoods)
+
+            buddy.minimize(
+                losses[loss_function], optimizer_name="train_dynamics_recurrent"
+            )
+            epoch_loss += fannypack.utils.to_numpy(losses[loss_function])
 
             # Logging
-            if batch_idx % log_interval == 0:
-                buddy.log("loss", loss)
+            if log_flag:
+                buddy.log("MSE loss", losses["mse"])
+                buddy.log("NLL loss", losses["nll"])
 
     # Print average training loss
     epoch_loss /= len(dataloader)
-    print("(train_dynamics_recurrent) Epoch training loss: ", epoch_loss)
+    print(
+        f"(train_dynamics_recurrent) Epoch training loss ({loss_function}): {epoch_loss}"
+    )


### PR DESCRIPTION
- Add covariance to output of `DynamicsModel.forward()`
- Made dynamics pretraining helpers default to NLL losses (formerly MSE)
- Synced docs